### PR TITLE
Make Boolean in JSON a string for display

### DIFF
--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -340,8 +340,8 @@ function format_json_array( $maybe_json ) {
 			// If the value isn't an array, make a basic list item.
 			if ( ! is_array( $value ) ) {
 
-				// Normalize value.
-				$value = var_export( $value, true );
+				// Make boolean a string for display.
+				$value = is_bool( $value ) ? var_export( $value, true ) : $value;
 
 				// Just wrap the piece as per usual.
 				$build .= '<span class="log-entry-json-array-piece">' . esc_html( $value ) . '</span>';

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -340,6 +340,9 @@ function format_json_array( $maybe_json ) {
 			// If the value isn't an array, make a basic list item.
 			if ( ! is_array( $value ) ) {
 
+				// Normalize value.
+				$value = var_export( $value, true );
+
 				// Just wrap the piece as per usual.
 				$build .= '<span class="log-entry-json-array-piece">' . esc_html( $value ) . '</span>';
 


### PR DESCRIPTION
Currently some JSON values are stripped from `esc_html()`.
fixes #13